### PR TITLE
IV 扫描页：新增吸收列以避免控件被拉伸

### DIFF
--- a/2400-2636b-controller.py
+++ b/2400-2636b-controller.py
@@ -1425,9 +1425,12 @@ class App:
 
         inner = ttk.Frame(page)
         inner.grid(row=0, column=0, pady=4, sticky="ew")
+        # 0~3 列都不参与“拉伸分配”，避免控件间距被撑大
         for col in range(4):
-            weight = 0 if col in (1, 3) else 1
-            inner.columnconfigure(col, weight=weight)
+            inner.columnconfigure(col, weight=0)
+
+        # 新增一个“空白吸收列”，专门吃掉窗口变宽时多出来的空间
+        inner.columnconfigure(4, weight=1)
 
         self.iv_source_mode_var = tk.StringVar(value="Voltage")
         self.iv_start_var = tk.DoubleVar(value=-1.0)


### PR DESCRIPTION
### Motivation
- 调整 IV 扫描页布局，使 label/entry 间距在窗口变宽时保持紧凑，并把多余宽度吸收到一个空白列中。

### Description
- 在 `2400-2636b-controller.py` 的 `_build_iv_tab` 中将原来对列 0~3 的拉伸权重改为 0，并新增第 4 列 `inner.columnconfigure(4, weight=1)` 作为吸收列，保留现有控件列号与 `columnspan=4` 布局。

### Testing
- 未运行任何自动化测试（没有请求自动测试）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764efb51b08333ac6745c5b4452e5f)